### PR TITLE
Validations for Parent and Child usernames/emails

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -27,7 +27,7 @@ class ChildrenController < ApplicationController
     private
 
     def child_params
-        params.permit(:username, :password, :image, :parent_id)
+        params.permit(:username, :password, :image, :parent_id, :name)
     end
 
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,7 +1,8 @@
 class Child < ApplicationRecord
     has_secure_password
-    # validates :username, uniqueness: { case_sensitive: false }
     belongs_to :parent 
     has_many :video_entries
     has_many :video_reports, through: :video_entries
+
+    validates :username, uniqueness: { case_sensitive: false }
 end

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -3,6 +3,10 @@ class Parent < ApplicationRecord
     has_many :children
     has_many :video_reports
 
+    validates_presence_of :email, :password_digest
+    validates_format_of :email, with: URI::MailTo::EMAIL_REGEXP
+    validates :email, uniqueness: { case_sensitive: false }
+
     def send_password_reset
         self.password_reset_token = generate_base64_token
         self.password_reset_sent_at = Time.zone.now

--- a/app/serializers/child_serializer.rb
+++ b/app/serializers/child_serializer.rb
@@ -1,5 +1,5 @@
 class ChildSerializer < ActiveModel::Serializer
-  attributes :id, :username, :image, :parent_email, :parent
+  attributes :id, :username, :name, :image, :parent_email, :parent
 
   has_many :video_entries
 

--- a/db/migrate/20210523190935_add_name_to_children.rb
+++ b/db/migrate/20210523190935_add_name_to_children.rb
@@ -1,0 +1,5 @@
+class AddNameToChildren < ActiveRecord::Migration[6.0]
+  def change
+    add_column :children, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_10_201938) do
+ActiveRecord::Schema.define(version: 2021_05_23_190935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2021_05_10_201938) do
     t.integer "parent_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "name"
   end
 
   create_table "parents", force: :cascade do |t|


### PR DESCRIPTION
Required a new migration for "name" attribute for Children table so that children with the same name can exist, but username must remain unique. 