### PR TITLE
Video fetch limit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::API
       end
     
       def decoded_token
-        if auth_header
+        if auth_header()
           token = auth_header.split(' ')[1]
           begin
             JWT.decode(token, ENV['jwt_key'], true, algorithm: 'HS256')

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,4 +10,6 @@ class SessionsController < ApplicationController
     end
   end
 
+  const arrow = () => { return}
+
 end

--- a/app/controllers/video_entries_controller.rb
+++ b/app/controllers/video_entries_controller.rb
@@ -3,7 +3,7 @@ class VideoEntriesController < ApplicationController
 
     def index
         video_entries = VideoEntry.all
-        render json: video_entries
+        render json: video_entries, adapter: nil
     end
 
     def show

--- a/app/controllers/video_entries_controller.rb
+++ b/app/controllers/video_entries_controller.rb
@@ -5,11 +5,17 @@
     class VideoEntriesController < ApplicationController
         skip_before_action :authorized_child, :authorized_parent, only: [:create, :destroy]
    
+        def show
+            video_entry = VideoEntry.find(params[:id])
+            puts video_entry
+            # attached_video = video_entry.video.attach(params[:video])
+            render json: video_entry
+        end
+
         def create
             video_entry = VideoEntry.create!(video_entry_params)
             attached_video = video_entry.video.attach(params[:video])    
             render json: video_entry
-            
         end
 
         def destroy

--- a/app/controllers/video_entries_controller.rb
+++ b/app/controllers/video_entries_controller.rb
@@ -1,5 +1,10 @@
 class VideoEntriesController < ApplicationController
-    skip_before_action :authorized_child, :authorized_parent, only: [:show, :create, :destroy]
+    skip_before_action :authorized_child, :authorized_parent, only: [:index, :show, :create, :destroy]
+
+    def index
+        video_entries = VideoEntry.all
+        render json: video_entries
+    end
 
     def show
         video_entry = VideoEntry.find(params[:id])

--- a/app/controllers/video_entries_controller.rb
+++ b/app/controllers/video_entries_controller.rb
@@ -1,38 +1,30 @@
-    require 'uri'
-    require 'net/http'
-    require 'openssl' 
-    
-    class VideoEntriesController < ApplicationController
-        skip_before_action :authorized_child, :authorized_parent, only: [:create, :destroy]
-   
-        def show
-            video_entry = VideoEntry.find(params[:id])
-            puts video_entry
-            # attached_video = video_entry.video.attach(params[:video])
-            render json: video_entry
-        end
+class VideoEntriesController < ApplicationController
+    skip_before_action :authorized_child, :authorized_parent, only: [:show, :create, :destroy]
 
-        def create
-            video_entry = VideoEntry.create!(video_entry_params)
-            attached_video = video_entry.video.attach(params[:video])    
-            render json: video_entry
-        end
-
-        def destroy
-            video_entry = VideoEntry.find(params[:id])
-            video_entry.destroy!
-            render json: {}
-        end
-    
-        private
-    
-        def video_entry_params
-            params.permit( :title, :video, :child_id)
-        end
-    
+    def show
+        video_entry = VideoEntry.find(params[:id])
+        render json: video_entry
     end
-    
-    
+
+    def create
+        video_entry = VideoEntry.create!(video_entry_params)
+        attached_video = video_entry.video.attach(params[:video])    
+        render json: video_entry
+    end
+
+    def destroy
+        video_entry = VideoEntry.find(params[:id])
+        video_entry.destroy!
+        render json: {}
+    end
+
+    private
+
+    def video_entry_params
+        params.permit( :title, :video, :child_id)
+    end
+
+end
     
 
 

--- a/app/controllers/video_reports_controller.rb
+++ b/app/controllers/video_reports_controller.rb
@@ -1,6 +1,8 @@
     class VideoReportsController < ApplicationController
         skip_before_action :authorized_child, :authorized_parent, only: [ :create]
   
+        
+
         def create
             video_report = VideoReport.create!(video_report_params)
             render json: video_report

--- a/app/serializers/child_serializer.rb
+++ b/app/serializers/child_serializer.rb
@@ -1,10 +1,14 @@
 class ChildSerializer < ActiveModel::Serializer
-  attributes :id, :username, :name, :image, :parent_email, :parent
+  attributes :id, :username, :name, :image, :parent_email, :parent, :video_entries
 
   has_many :video_reports
 
   def parent_email
     self.object.parent.email
+  end
+
+  def video_entries
+    self.object.video_entries
   end
 
 end

--- a/app/serializers/child_serializer.rb
+++ b/app/serializers/child_serializer.rb
@@ -1,7 +1,8 @@
 class ChildSerializer < ActiveModel::Serializer
   attributes :id, :username, :name, :image, :parent_email, :parent
 
-  has_many :video_entries
+  # Commented out to test video fetch limit upon login
+  # has_many :video_entries
 
   def parent_email
     self.object.parent.email

--- a/app/serializers/child_serializer.rb
+++ b/app/serializers/child_serializer.rb
@@ -1,8 +1,7 @@
 class ChildSerializer < ActiveModel::Serializer
   attributes :id, :username, :name, :image, :parent_email, :parent
 
-  # Commented out to test video fetch limit upon login
-  # has_many :video_entries
+  has_many :video_reports
 
   def parent_email
     self.object.parent.email


### PR DESCRIPTION
Note: 
- ChildSerializer required custom method to add video_entries without the video files loading. 
- VideoEntriesController required to have 'adapter: nil' in the index method to avoid the serializer and loading the video files.
- VideoCard holds each loaded video in local state until page is refreshed or changed. To make it a more permanent cache the redux store needs to be updated and it needs to be held there.
